### PR TITLE
Enable port selection for OpenAPI extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ chmod +x start_bedrock_mcp.sh
 To ensure all OpenAPI endpoints are mapped to MCP functions (and vice versa), this project includes automated coverage scripts:
 
 1. **Extract OpenAPI Endpoints:**
-   - `extract_openapi_endpoints.py` reads your `openapi.json` and outputs all endpoints with their `operationId`s to `openapi_endpoints.json`.
+   - `extract_openapi_endpoints.py` fetches the OpenAPI spec from your running Bedrock Server Manager instance (host and port configurable) and outputs all endpoints with their `operationId`s to `openapi_endpoints.json`.
 2. **Extract MCP Functions:**
    - `extract_mcp_functions.py` scans `bedrock_mcp_server.py` for MCP-exposed functions (decorated with `@mcp_tool_testable`) and outputs them to `mcp_functions.json`.
 3. **Run Coverage Test:**
@@ -207,11 +207,11 @@ To ensure all OpenAPI endpoints are mapped to MCP functions (and vice versa), th
 
 ### How to Use
 
-1. Ensure your OpenAPI spec is available as `openapi.json` in the project root.
-2. Run:
-   ```bash
-   python run_api_coverage_check.py
-   ```
+Run the coverage workflow and optionally specify the server host and port
+(defaults `localhost` and `11325`):
+```bash
+python run_api_coverage_check.py [server] [port]
+```
    This will:
    - Generate `openapi_endpoints.json` and `mcp_functions.json`
    - Run the coverage test and print any missing or extra mappings

--- a/run_api_coverage_check.py
+++ b/run_api_coverage_check.py
@@ -1,6 +1,5 @@
 import subprocess
 import sys
-from pathlib import Path
 
 EXTRACT_OPENAPI = [sys.executable, "extract_openapi_endpoints.py"]
 EXTRACT_MCP = [sys.executable, "extract_mcp_functions.py"]
@@ -19,8 +18,14 @@ def run_and_save(cmd, outfile):
         sys.exit(result.returncode)
 
 
+DEFAULT_SERVER = "localhost"
+DEFAULT_PORT = 11325
+
+
 def main():
-    run_and_save(EXTRACT_OPENAPI, OPENAPI_JSON)
+    server = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_SERVER
+    port = sys.argv[2] if len(sys.argv) > 2 else str(DEFAULT_PORT)
+    run_and_save(EXTRACT_OPENAPI + [server, port], OPENAPI_JSON)
     run_and_save(EXTRACT_MCP, MCP_JSON)
     print(f"\nRunning pytest on {COVERAGE_TEST}...\n")
     code = subprocess.call([sys.executable, "-m", "pytest", COVERAGE_TEST])


### PR DESCRIPTION
## Summary
- allow `extract_openapi_endpoints.py` to take server and port arguments
- forward port option through `run_api_coverage_check.py`
- document optional server and port parameters in the README

## Testing
- `pytest -q` *(fails: FileNotFoundError: openapi_endpoints.json)*

------
https://chatgpt.com/codex/tasks/task_b_6883c0f43e7c832fb18f877c304de424